### PR TITLE
Comment out restriction on timezone usage.

### DIFF
--- a/lib/groupdate/relation_builder.rb
+++ b/lib/groupdate/relation_builder.rb
@@ -11,9 +11,11 @@ module Groupdate
       @week_start = week_start
       @day_start = day_start
 
-      if relation.default_timezone == :local
-        raise Groupdate::Error, "ActiveRecord::Base.default_timezone must be :utc to use Groupdate"
-      end
+      # Commenting out due to timezone issues. It's a workaround,
+      # see commit message for more information, or speak to @maxshelley
+      # if relation.default_timezone == :local
+      #   raise Groupdate::Error, "ActiveRecord::Base.default_timezone must be :utc to use Groupdate"
+      # end
     end
 
     def generate


### PR DESCRIPTION
We are aware of the issues that this can create, but need to get a temporary version of
the grouped data up and running even with timezone issues, so removing this in a custom
fork.